### PR TITLE
turn off full screen mode

### DIFF
--- a/webssh/static/js/main.js
+++ b/webssh/static/js/main.js
@@ -201,7 +201,7 @@ jQuery(function($){
         sock = new window.WebSocket(url),
         encoding = 'utf-8',
         decoder = window.TextDecoder ? new window.TextDecoder(encoding) : encoding,
-        terminal = document.getElementById('#terminal'),
+        terminal = document.getElementById('terminal'),
         term = new window.Terminal({
           cursorBlink: true,
         });
@@ -328,9 +328,9 @@ jQuery(function($){
     });
 
     sock.onopen = function() {
-      $('.container').hide();
+      $('#form-container').hide();
       term.open(terminal, true);
-      term.toggleFullscreen(true);
+      term.toggleFullscreen(false);
       state = CONNECTED;
       title_element.text = title_text;
     };

--- a/webssh/templates/index.html
+++ b/webssh/templates/index.html
@@ -27,7 +27,7 @@
     </style>
   </head>
   <body>
-    <div class="container">
+    <div class="container" id="form-container">
       <form id="connect" action="" method="post" enctype="multipart/form-data"{% if debug %} novalidate{% end %}>
         <div class="row">
           <div class="col">


### PR DESCRIPTION
Terminalを開くとフルスクリーンになるのを修正しました．
元のwebsshでおかしかったところも修正してます．
getElementById関数では"#terminal"ではなく"terminal"でよい．
接続後にhideするdiv要素をcontainerクラスで指定していた（terminal部分とform部分が別々のcontainerになっており曖昧）のでidで指定するようにし，form部分だけhideするようにした．