### PR TITLE
modified tornado require version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         'Programming Language :: Python :: 3.7',
     ],
     install_requires=[
-        'tornado>=4.5.0',
+        'tornado<=5.1.1',
         'paramiko>=2.3.1',
     ],
 )


### PR DESCRIPTION
v6.0.1だとtornado使用時にwsshが落ちたためinstall_requiresを'tornado>=4.5.0'から'tornado<=5.1.1',に修正